### PR TITLE
2023.10 Release

### DIFF
--- a/website/actions/add_game.php
+++ b/website/actions/add_game.php
@@ -46,6 +46,10 @@ if(!checkdate($date[1], $date[2], $date[0]))
 	returnJSONAndDie(-1, "Invalid Date Format");
 }
 
+if ($date[0] > 3000)
+{
+	returnJSONAndDie(-1, "Invalid Date Format"); // Implementing fix for https://github.com/TheGamesDB2/Website/issues/20 - example date 20223 in theory is a valid date, as such put a limit of 3000.
+}
 
 require_once __DIR__ . "/../../include/TGDB.API.php";
 require_once __DIR__ . "/../include/DiscordUtils.class.php";

--- a/website/actions/add_game.php
+++ b/website/actions/add_game.php
@@ -103,7 +103,7 @@ try
 	}
 
 	$conditions = [];
-	$conditions['game_title'] = [htmlspecialchars($_REQUEST['game_title']), PDO::PARAM_STR];
+	$conditions['game_title'] = [htmlspecialchars(trim($_REQUEST['game_title'])), PDO::PARAM_STR];
 	$conditions['overview'] = [htmlspecialchars($_REQUEST['overview']), PDO::PARAM_STR];
 	$conditions['youtube'] = [htmlspecialchars($_REQUEST['youtube']), PDO::PARAM_STR];
 

--- a/website/include/header.footer.class.php
+++ b/website/include/header.footer.class.php
@@ -68,9 +68,9 @@ class HEADER
 				echo '<link rel="stylesheet" href="/css/materia-bootstrap.min.css" crossorigin="anonymous">';
 		}
 	?>
-	<script src="https://code.jquery.com/jquery-3.2.1.min.js" crossorigin="anonymous"></script>
-	<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.13.0/umd/popper.min.js"></script>
-	<script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/js/bootstrap.min.js" integrity="sha384-JZR6Spejh4U02d8jOt6vLEHfe/JQGiRRSQQxSfFWpi1MquVdAyjUar5+76PVCmYl" crossorigin="anonymous"></script>
+	<script type="text/javascript" src="/js/jquery-3.2.1.min.js"></script>
+	<script type="text/javascript" src="/js/popper.min.1.13.0.js"></script>
+	<script type="text/javascript" src="/js/bootstrap.min.4.0.0.js"></script>
 	<link rel="stylesheet" href="/css/main.css" crossorigin="anonymous">
 	<?php if(isset($this->_printExtraHeader)) : call_user_func($this->_printExtraHeader); endif; ?>
 </head>

--- a/website/index.php
+++ b/website/index.php
@@ -118,6 +118,7 @@ $Header->appendRawHeader(function() { ?>
 										<a href="/game.php?id=<?= $game->id ?>">
 											<?= $game->game_title ?>
 											<br/>
+											<?= $game->release_date ?>
 											<span class="text-muted"><?= $Platforms[$game->platform]->name ?></span>
 										</a>
 									</th>

--- a/website/index.php
+++ b/website/index.php
@@ -118,7 +118,8 @@ $Header->appendRawHeader(function() { ?>
 										<a href="/game.php?id=<?= $game->id ?>">
 											<?= $game->game_title ?>
 											<br/>
-											<?= $game->release_date ?>
+											<span class="text-muted">(<?= $game->release_date ?>)</span>
+											<br/>
 											<span class="text-muted"><?= $Platforms[$game->platform]->name ?></span>
 										</a>
 									</th>


### PR DESCRIPTION
Fixed issues:
- When adding a game, spaces at the start or the end of the title were sometimes added, this has now been resolved to remove spaces at the start or end.
- Date formatting whilst was validating correctly, the validation allowed a year up to 32767, whilst we would like the site to run to the year 32767, we've put in a limit of 3000. This is beyond the expectation of the site however it will stop years like 20223 being added as a typo.
- External CDNs for JS files etc have been removed and we have reverted back to using local resources.
- On the home page the section games released soon did not display the date of the release. This has now been added.