### PR TITLE
Fix issues with the header and footer items taking up too much space

### DIFF
--- a/website/add_dev_pub.php
+++ b/website/add_dev_pub.php
@@ -34,13 +34,11 @@ $Header->setTitle("TGDB - Add Dev/Pub");
 $Header->appendRawHeader(function() { global $_user, $devs_list, $pubs_list; ?>
 
 	<link href="/css/social-btn.css" rel="stylesheet">
-	<link href="/css/fontawesome.5.0.10.css" rel="stylesheet">
 	<link href="/css/fa-brands.5.0.10.css" rel="stylesheet">
 	<link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.1.0/css/all.css" integrity="sha384-lKuwvrZot6UHsBSfcMvOkWwlCMgc0TaWr+30HWe3a4ltaBwTZhyTEggF5tJv8tbt" crossorigin="anonymous">
 	<link href="/css/jquery.fancybox.min.3.3.5.css" rel="stylesheet">
 
 	<script type="text/javascript" defer src="/js/brands.5.0.10.js" crossorigin="anonymous"></script>
-	<script type="text/javascript" defer src="/js/fontawesome.5.0.10.js" crossorigin="anonymous"></script>
 
 	<script type="text/javascript" src="/js/jquery.fancybox.3.3.5.js"></script>
 	<script type="text/javascript" src="/js/fancybox.config.js"></script>

--- a/website/add_dev_pub.php
+++ b/website/add_dev_pub.php
@@ -34,11 +34,8 @@ $Header->setTitle("TGDB - Add Dev/Pub");
 $Header->appendRawHeader(function() { global $_user, $devs_list, $pubs_list; ?>
 
 	<link href="/css/social-btn.css" rel="stylesheet">
-	<link href="/css/fa-brands.5.0.10.css" rel="stylesheet">
 	<link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.1.0/css/all.css" integrity="sha384-lKuwvrZot6UHsBSfcMvOkWwlCMgc0TaWr+30HWe3a4ltaBwTZhyTEggF5tJv8tbt" crossorigin="anonymous">
 	<link href="/css/jquery.fancybox.min.3.3.5.css" rel="stylesheet">
-
-	<script type="text/javascript" defer src="/js/brands.5.0.10.js" crossorigin="anonymous"></script>
 
 	<script type="text/javascript" src="/js/jquery.fancybox.3.3.5.js"></script>
 	<script type="text/javascript" src="/js/fancybox.config.js"></script>

--- a/website/add_game.php
+++ b/website/add_game.php
@@ -41,10 +41,8 @@ $Header->appendRawHeader(function() { global $devs_list, $pubs_list; ?>
 
 	<link href="/css/select-pure.css" rel="stylesheet">
 	<link href="/css/social-btn.css" rel="stylesheet">
-	<link href="/css/fa-brands.5.0.10.css" rel="stylesheet">
 	<link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.1.0/css/all.css" integrity="sha384-lKuwvrZot6UHsBSfcMvOkWwlCMgc0TaWr+30HWe3a4ltaBwTZhyTEggF5tJv8tbt" crossorigin="anonymous">
 
-	<script type="text/javascript" defer src="/js/brands.5.0.10.js" crossorigin="anonymous"></script>
 	<script type="text/javascript" src="/js/pure-select.modded.0.6.2.js"></script>
 
 

--- a/website/add_game.php
+++ b/website/add_game.php
@@ -41,12 +41,10 @@ $Header->appendRawHeader(function() { global $devs_list, $pubs_list; ?>
 
 	<link href="/css/select-pure.css" rel="stylesheet">
 	<link href="/css/social-btn.css" rel="stylesheet">
-	<link href="/css/fontawesome.5.0.10.css" rel="stylesheet">
 	<link href="/css/fa-brands.5.0.10.css" rel="stylesheet">
 	<link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.1.0/css/all.css" integrity="sha384-lKuwvrZot6UHsBSfcMvOkWwlCMgc0TaWr+30HWe3a4ltaBwTZhyTEggF5tJv8tbt" crossorigin="anonymous">
 
 	<script type="text/javascript" defer src="/js/brands.5.0.10.js" crossorigin="anonymous"></script>
-	<script type="text/javascript" defer src="/js/fontawesome.5.0.10.js" crossorigin="anonymous"></script>
 	<script type="text/javascript" src="/js/pure-select.modded.0.6.2.js"></script>
 
 

--- a/website/add_platform.php
+++ b/website/add_platform.php
@@ -34,11 +34,8 @@ $Header->setTitle("TGDB - Add Platforms");
 $Header->appendRawHeader(function() { global $_user, $devs_list, $pubs_list; ?>
 
 	<link href="/css/social-btn.css" rel="stylesheet">
-	<link href="/css/fa-brands.5.0.10.css" rel="stylesheet">
 	<link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.1.0/css/all.css" integrity="sha384-lKuwvrZot6UHsBSfcMvOkWwlCMgc0TaWr+30HWe3a4ltaBwTZhyTEggF5tJv8tbt" crossorigin="anonymous">
 	<link href="/css/jquery.fancybox.min.3.3.5.css" rel="stylesheet">
-
-	<script type="text/javascript" defer src="/js/brands.5.0.10.js" crossorigin="anonymous"></script>
 
 	<script type="text/javascript" src="/js/jquery.fancybox.3.3.5.js"></script>
 	<script type="text/javascript" src="/js/fancybox.config.js"></script>

--- a/website/add_platform.php
+++ b/website/add_platform.php
@@ -34,13 +34,11 @@ $Header->setTitle("TGDB - Add Platforms");
 $Header->appendRawHeader(function() { global $_user, $devs_list, $pubs_list; ?>
 
 	<link href="/css/social-btn.css" rel="stylesheet">
-	<link href="/css/fontawesome.5.0.10.css" rel="stylesheet">
 	<link href="/css/fa-brands.5.0.10.css" rel="stylesheet">
 	<link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.1.0/css/all.css" integrity="sha384-lKuwvrZot6UHsBSfcMvOkWwlCMgc0TaWr+30HWe3a4ltaBwTZhyTEggF5tJv8tbt" crossorigin="anonymous">
 	<link href="/css/jquery.fancybox.min.3.3.5.css" rel="stylesheet">
 
 	<script type="text/javascript" defer src="/js/brands.5.0.10.js" crossorigin="anonymous"></script>
-	<script type="text/javascript" defer src="/js/fontawesome.5.0.10.js" crossorigin="anonymous"></script>
 
 	<script type="text/javascript" src="/js/jquery.fancybox.3.3.5.js"></script>
 	<script type="text/javascript" src="/js/fancybox.config.js"></script>

--- a/website/contr.php
+++ b/website/contr.php
@@ -35,8 +35,6 @@ $Header->appendRawHeader(function() { global $Game, $_user; ?>
 	<link href="/css/fa-brands.5.0.10.css" rel="stylesheet">
 	<link href="/css/jquery.fancybox.min.3.3.5.css" rel="stylesheet">
 
-	<script defer src="/js/brands.5.0.10.js" crossorigin="anonymous"></script>
-
 	<script src="/js/jquery.fancybox.3.3.5.js"></script>
 	<script src="/js/fancybox.config.js"></script>
 

--- a/website/contr.php
+++ b/website/contr.php
@@ -32,12 +32,10 @@ $Header->setTitle("TGDB - Browse - GameEdits - $Game->game_title");
 $Header->appendRawHeader(function() { global $Game, $_user; ?>
 
 	<link href="/css/social-btn.css" rel="stylesheet">
-	<link href="/css/fontawesome.5.0.10.css" rel="stylesheet">
 	<link href="/css/fa-brands.5.0.10.css" rel="stylesheet">
 	<link href="/css/jquery.fancybox.min.3.3.5.css" rel="stylesheet">
 
 	<script defer src="/js/brands.5.0.10.js" crossorigin="anonymous"></script>
-	<script defer src="/js/fontawesome.5.0.10.js" crossorigin="anonymous"></script>
 
 	<script src="/js/jquery.fancybox.3.3.5.js"></script>
 	<script src="/js/fancybox.config.js"></script>

--- a/website/css/fontawesome.5.0.10.css
+++ b/website/css/fontawesome.5.0.10.css
@@ -2,6 +2,21 @@
  * Font Awesome Free 5.0.10 by @fontawesome - https://fontawesome.com
  * License - https://fontawesome.com/license (Icons: CC BY 4.0, Fonts: SIL OFL 1.1, Code: MIT License)
  */
+:root, :host {
+  --fa-style-family-classic: 'Font Awesome 5 Free';
+  --fa-font-solid: normal 900 1em/1 'Font Awesome 5 Free'; }
+
+@font-face {
+  font-family: 'Font Awesome 5 Free';
+  font-style: normal;
+  font-weight: 900;
+  font-display: block;
+  src: url("webfonts/fa-solid-900.woff2") format("woff2"), url("webfonts/fa-solid-900.ttf") format("truetype"); }
+
+.fas,
+.fa-solid {
+  font-weight: 900; }
+
  .fa,
  .fas,
  .far,
@@ -10,6 +25,7 @@
    -moz-osx-font-smoothing: grayscale;
    -webkit-font-smoothing: antialiased;
    display: inline-block;
+   font-family: 'Font Awesome 5 Free';
    font-style: normal;
    font-variant: normal;
    text-rendering: auto;

--- a/website/css/main.css
+++ b/website/css/main.css
@@ -149,3 +149,67 @@ h1, h2, h3, h4, h5, h6
 {
 	text-transform: none !important;
 }
+
+#search-form {
+	background: white;
+	border-radius: 0.25em;
+	font-size: 11pt;
+	padding: 0.25em;
+	width: 230px;
+}
+
+#search-form button,
+#search-form input {
+	background: white;
+	border: 0;
+	display: inline-block;
+	font-family: inherit;
+}
+
+#search-form button {
+	cursor: pointer;
+	color: gray;
+}
+
+#search-form button:hover {
+	color: black;
+}
+
+#search-form input {
+	outline: none;
+	width: 200px;
+}
+
+@media (min-width: 992px) {
+	#search-form {
+		width: auto;
+	}
+
+	#search-form input {
+		width: 130px;
+	}
+
+	.navbar-nav .btn {
+		padding: 0;
+	}
+
+	.navbar-nav .nav-item {
+		margin-right: 1rem;
+		margin-right: 1rem;
+	}
+}
+
+@media (min-width: 1200px) {
+	#search-form input {
+		width: 240px;
+	}
+
+	.navbar-nav .btn {
+		padding: 0;
+	}
+
+	.navbar-nav .nav-item {
+		margin-right: 1rem;
+		margin-right: 1rem;
+	}
+}

--- a/website/edit_game.php
+++ b/website/edit_game.php
@@ -107,11 +107,8 @@ $Header->appendRawHeader(function() { global $Game, $_user, $game_devs, $devs_li
 
 	<link href="/css/select-pure.css" rel="stylesheet">
 	<link href="/css/social-btn.css" rel="stylesheet">
-	<link href="/css/fa-brands.5.0.10.css" rel="stylesheet">
 	<link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.1.0/css/all.css" integrity="sha384-lKuwvrZot6UHsBSfcMvOkWwlCMgc0TaWr+30HWe3a4ltaBwTZhyTEggF5tJv8tbt" crossorigin="anonymous">
 	<link href="/css/jquery.fancybox.min.3.3.5.css" rel="stylesheet">
-
-	<script type="text/javascript" defer src="/js/brands.5.0.10.js" crossorigin="anonymous"></script>
 
 	<script type="text/javascript" src="/js/jquery.fancybox.3.3.5.js"></script>
 	<script type="text/javascript" src="/js/fancybox.config.js"></script>

--- a/website/edit_game.php
+++ b/website/edit_game.php
@@ -107,13 +107,11 @@ $Header->appendRawHeader(function() { global $Game, $_user, $game_devs, $devs_li
 
 	<link href="/css/select-pure.css" rel="stylesheet">
 	<link href="/css/social-btn.css" rel="stylesheet">
-	<link href="/css/fontawesome.5.0.10.css" rel="stylesheet">
 	<link href="/css/fa-brands.5.0.10.css" rel="stylesheet">
 	<link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.1.0/css/all.css" integrity="sha384-lKuwvrZot6UHsBSfcMvOkWwlCMgc0TaWr+30HWe3a4ltaBwTZhyTEggF5tJv8tbt" crossorigin="anonymous">
 	<link href="/css/jquery.fancybox.min.3.3.5.css" rel="stylesheet">
 
 	<script type="text/javascript" defer src="/js/brands.5.0.10.js" crossorigin="anonymous"></script>
-	<script type="text/javascript" defer src="/js/fontawesome.5.0.10.js" crossorigin="anonymous"></script>
 
 	<script type="text/javascript" src="/js/jquery.fancybox.3.3.5.js"></script>
 	<script type="text/javascript" src="/js/fancybox.config.js"></script>

--- a/website/edit_platform.php
+++ b/website/edit_platform.php
@@ -46,13 +46,11 @@ $Header->setTitle("TGDB - Edit Platforms");
 $Header->appendRawHeader(function() { global $_user; ?>
 
 	<link href="/css/social-btn.css" rel="stylesheet">
-	<link href="/css/fontawesome.5.0.10.css" rel="stylesheet">
 	<link href="/css/fa-brands.5.0.10.css" rel="stylesheet">
 	<link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.1.0/css/all.css" integrity="sha384-lKuwvrZot6UHsBSfcMvOkWwlCMgc0TaWr+30HWe3a4ltaBwTZhyTEggF5tJv8tbt" crossorigin="anonymous">
 	<link href="/css/jquery.fancybox.min.3.3.5.css" rel="stylesheet">
 
 	<script type="text/javascript" defer src="/js/brands.5.0.10.js" crossorigin="anonymous"></script>
-	<script type="text/javascript" defer src="/js/fontawesome.5.0.10.js" crossorigin="anonymous"></script>
 
 	<script type="text/javascript" src="/js/jquery.fancybox.3.3.5.js"></script>
 	<script type="text/javascript" src="/js/fancybox.config.js"></script>

--- a/website/edit_platform.php
+++ b/website/edit_platform.php
@@ -46,11 +46,8 @@ $Header->setTitle("TGDB - Edit Platforms");
 $Header->appendRawHeader(function() { global $_user; ?>
 
 	<link href="/css/social-btn.css" rel="stylesheet">
-	<link href="/css/fa-brands.5.0.10.css" rel="stylesheet">
 	<link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.1.0/css/all.css" integrity="sha384-lKuwvrZot6UHsBSfcMvOkWwlCMgc0TaWr+30HWe3a4ltaBwTZhyTEggF5tJv8tbt" crossorigin="anonymous">
 	<link href="/css/jquery.fancybox.min.3.3.5.css" rel="stylesheet">
-
-	<script type="text/javascript" defer src="/js/brands.5.0.10.js" crossorigin="anonymous"></script>
 
 	<script type="text/javascript" src="/js/jquery.fancybox.3.3.5.js"></script>
 	<script type="text/javascript" src="/js/fancybox.config.js"></script>

--- a/website/game.php
+++ b/website/game.php
@@ -90,12 +90,10 @@ $Header->appendRawHeader(function() { global $Game, $box_cover, $_user; ?>
 	<meta property="og:description" content="<?= htmlspecialchars($Game->overview); ?>" />
 
 	<link href="/css/social-btn.css" rel="stylesheet">
-	<link href="/css/fontawesome.5.0.10.css" rel="stylesheet">
 	<link href="/css/fa-brands.5.0.10.css" rel="stylesheet">
 	<link href="/css/jquery.fancybox.min.3.3.5.css" rel="stylesheet">
 
 	<script defer src="/js/brands.5.0.10.js" crossorigin="anonymous"></script>
-	<script defer src="/js/fontawesome.5.0.10.js" crossorigin="anonymous"></script>
 
 	<script src="/js/jquery.fancybox.3.3.5.js"></script>
 	<script src="/js/fancybox.config.js"></script>

--- a/website/game.php
+++ b/website/game.php
@@ -90,10 +90,7 @@ $Header->appendRawHeader(function() { global $Game, $box_cover, $_user; ?>
 	<meta property="og:description" content="<?= htmlspecialchars($Game->overview); ?>" />
 
 	<link href="/css/social-btn.css" rel="stylesheet">
-	<link href="/css/fa-brands.5.0.10.css" rel="stylesheet">
 	<link href="/css/jquery.fancybox.min.3.3.5.css" rel="stylesheet">
-
-	<script defer src="/js/brands.5.0.10.js" crossorigin="anonymous"></script>
 
 	<script src="/js/jquery.fancybox.3.3.5.js"></script>
 	<script src="/js/fancybox.config.js"></script>

--- a/website/include/header.footer.class.php
+++ b/website/include/header.footer.class.php
@@ -71,6 +71,8 @@ class HEADER
 	<script type="text/javascript" src="/js/jquery-3.2.1.min.js"></script>
 	<script type="text/javascript" src="/js/popper.min.1.13.0.js"></script>
 	<script type="text/javascript" src="/js/bootstrap.min.4.0.0.js"></script>
+	<script type="text/javascript" src="/js/fontawesome.5.0.10.js"></script>
+	<link rel="stylesheet" href="/css/fontawesome.5.0.10.css" crossorigin="anonymous">
 	<link rel="stylesheet" href="/css/main.css" crossorigin="anonymous">
 	<?php if(isset($this->_printExtraHeader)) : call_user_func($this->_printExtraHeader); endif; ?>
 	<?php if(!$_user->isLoggedIn()) : ?>

--- a/website/include/header.footer.class.php
+++ b/website/include/header.footer.class.php
@@ -169,10 +169,10 @@ class FOOTER
 		<footer class="container-fluid bg-dark" style="margin-top:10px; padding: 20px;">
 			<div class="container">
 				<div class="row">
-					<div class="col-sm-3">
+					<div class="col-lg-3">
 						<h2 class="logo"><a href="/"> TheGamesDB </a></h2>
 					</div>
-					<div class="col-sm-2">
+					<div class="col-sm-4 col-lg-2">
 						<h5>Get started</h5>
 						<ul>
 							<li><a href="/">Home</a></li>
@@ -186,7 +186,7 @@ class FOOTER
 							<li><a href="/stats.php">Stats</a></li>
 						</ul>
 					</div>
-					<div class="col-sm-3">
+					<div class="col-sm-4 col-lg-3">
 						<h5>Developers</h5>
 						<ul>
 							<li><a href="https://api.thegamesdb.net/">API Documentation</a></li>
@@ -195,7 +195,7 @@ class FOOTER
 						</ul>
 					</div>
 					<?php if(false) : ?>
-					<div class="col-sm-2">
+					<div class="col-lg-2">
 						<h5>About us</h5>
 						<ul>
 							<li><a href="#">Company Information</a></li>
@@ -203,7 +203,7 @@ class FOOTER
 							<li><a href="#">Reviews</a></li>
 						</ul>
 					</div>
-					<div class="col-sm-2">
+					<div class="col-lg-2">
 						<h5>Support</h5>
 						<ul>
 							<li><a href="#">FAQ</a></li>
@@ -212,7 +212,7 @@ class FOOTER
 						</ul>
 					</div>
 					<?php endif;?>
-					<div class="col-sm-3">
+					<div class="col-sm-4 col-lg-3">
 						<div class="social-networks">
 							<a href="https://twitter.com/thegamesdb" class="twitter"><i class="fab fa-twitter"></i></a>
 							<a href="https://www.facebook.com/thegamesdb/" class="facebook"><i class="fab fa-facebook"></i></a>

--- a/website/include/header.footer.class.php
+++ b/website/include/header.footer.class.php
@@ -95,12 +95,6 @@ class HEADER
 
 		<div class="collapse navbar-collapse" id="navbarColor01">
 			<ul class="navbar-nav mr-auto">
-				<li class="nav-item">
-					<a class="nav-link" href="/">Home</a>
-				</li>
-				<li class="nav-item">
-					<a class="nav-link" href="https://forums.thegamesdb.net/">Forums</a>
-				</li>
 				<li class="nav-item dropdown">
 					<a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
 					Browse
@@ -110,21 +104,22 @@ class HEADER
 						<a class="dropdown-item" href="/list_platforms.php">Platforms</a>
 						<a class="dropdown-item" href="/list_devs.php">Developers</a>
 						<a class="dropdown-item" href="/list_pubs.php">Publishers</a>
+						<a class="dropdown-item" href="/stats.php">Stats</a>
 					</div>
-				</li>
-				<li class="nav-item">
-					<a class="nav-link" href="/stats.php">Stats</a>
 				</li>
 				<li class="nav-item">
 					<a class="nav-link" href="/add_game.php">Add New Game</a>
 				</li>
 				<li class="nav-item">
+					<a class="nav-link" href="https://forums.thegamesdb.net/">Forums</a>
+				</li>
+				<li class="nav-item">
 					<a class="nav-link" href="https://www.patreon.com/thegamesdb" target="_blank">Patreon</a>
 				</li>
 			</ul>
-			<form action="/search.php" method="get" class="form-inline my-2 my-lg-0">
-				<input name="name" class="form-control mr-sm-2" type="text" placeholder="Search">
-				<button class="btn btn-secondary my-2 my-sm-0" type="submit">Search</button>
+			<form id="search-form" action="/search.php" method="get" class="form-inline my-2 my-lg-0">
+				<input name="name" type="text" placeholder="Search">
+				<button type="submit"><i class="fa fa-search" title="Search"></i></button>
 			</form>
 			<ul class="navbar-nav my-2 my-lg-0">
 				<?php if($_user->isLoggedIn()) : ?>
@@ -186,6 +181,7 @@ class FOOTER
 							<li><a href="/list_platforms.php">Platforms</a></li>
 							<li><a href="/list_devs.php">Developers</a></li>
 							<li><a href="/list_pubs.php">Publishers</a></li>
+							<li><a href="/stats.php">Stats</a></li>
 						</ul>
 					</div>
 					<div class="col-sm-3">

--- a/website/include/header.footer.class.php
+++ b/website/include/header.footer.class.php
@@ -72,7 +72,9 @@ class HEADER
 	<script type="text/javascript" src="/js/popper.min.1.13.0.js"></script>
 	<script type="text/javascript" src="/js/bootstrap.min.4.0.0.js"></script>
 	<script type="text/javascript" src="/js/fontawesome.5.0.10.js"></script>
+	<script type="text/javascript" src="/js/brands.5.0.10.js"></script>
 	<link rel="stylesheet" href="/css/fontawesome.5.0.10.css" crossorigin="anonymous">
+	<link rel="stylesheet" href="/css/fa-brands.5.0.10.css" crossorigin="anonymous">
 	<link rel="stylesheet" href="/css/main.css" crossorigin="anonymous">
 	<?php if(isset($this->_printExtraHeader)) : call_user_func($this->_printExtraHeader); endif; ?>
 	<?php if(!$_user->isLoggedIn()) : ?>

--- a/website/merge_dev_pub.php
+++ b/website/merge_dev_pub.php
@@ -35,13 +35,11 @@ $Header->appendRawHeader(function() { global $_user, $devs_list, $pubs_list; ?>
 
 	<link href="/css/select-pure.css" rel="stylesheet">
 	<link href="/css/social-btn.css" rel="stylesheet">
-	<link href="/css/fontawesome.5.0.10.css" rel="stylesheet">
 	<link href="/css/fa-brands.5.0.10.css" rel="stylesheet">
 	<link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.1.0/css/all.css" integrity="sha384-lKuwvrZot6UHsBSfcMvOkWwlCMgc0TaWr+30HWe3a4ltaBwTZhyTEggF5tJv8tbt" crossorigin="anonymous">
 	<link href="/css/jquery.fancybox.min.3.3.5.css" rel="stylesheet">
 
 	<script type="text/javascript" defer src="/js/brands.5.0.10.js" crossorigin="anonymous"></script>
-	<script type="text/javascript" defer src="/js/fontawesome.5.0.10.js" crossorigin="anonymous"></script>
 
 	<script type="text/javascript" src="/js/jquery.fancybox.3.3.5.js"></script>
 	<script type="text/javascript" src="/js/fancybox.config.js"></script>

--- a/website/merge_dev_pub.php
+++ b/website/merge_dev_pub.php
@@ -35,11 +35,8 @@ $Header->appendRawHeader(function() { global $_user, $devs_list, $pubs_list; ?>
 
 	<link href="/css/select-pure.css" rel="stylesheet">
 	<link href="/css/social-btn.css" rel="stylesheet">
-	<link href="/css/fa-brands.5.0.10.css" rel="stylesheet">
 	<link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.1.0/css/all.css" integrity="sha384-lKuwvrZot6UHsBSfcMvOkWwlCMgc0TaWr+30HWe3a4ltaBwTZhyTEggF5tJv8tbt" crossorigin="anonymous">
 	<link href="/css/jquery.fancybox.min.3.3.5.css" rel="stylesheet">
-
-	<script type="text/javascript" defer src="/js/brands.5.0.10.js" crossorigin="anonymous"></script>
 
 	<script type="text/javascript" src="/js/jquery.fancybox.3.3.5.js"></script>
 	<script type="text/javascript" src="/js/fancybox.config.js"></script>

--- a/website/platform.php
+++ b/website/platform.php
@@ -69,7 +69,6 @@ $Header->appendRawHeader(function()
 	<meta property="og:description" content="<?= htmlspecialchars($Platform->overview); ?>" />
 
 	<link href="/css/social-btn.css" rel="stylesheet">
-	<link href="/css/fa-brands.5.0.10.css" rel="stylesheet">
 	<link href="/css/jquery.fancybox.min.3.3.5.css" rel="stylesheet">
 
 	<script src="/js/jquery.fancybox.3.3.5.js"></script>

--- a/website/platform.php
+++ b/website/platform.php
@@ -69,7 +69,6 @@ $Header->appendRawHeader(function()
 	<meta property="og:description" content="<?= htmlspecialchars($Platform->overview); ?>" />
 
 	<link href="/css/social-btn.css" rel="stylesheet">
-	<link href="/css/fontawesome.5.0.10.css" rel="stylesheet">
 	<link href="/css/fa-brands.5.0.10.css" rel="stylesheet">
 	<link href="/css/jquery.fancybox.min.3.3.5.css" rel="stylesheet">
 

--- a/website/user_contrib.php
+++ b/website/user_contrib.php
@@ -53,10 +53,7 @@ $Header->setTitle("TGDB - Browse - Game - $Game->game_title");
 $Header->appendRawHeader(function() { global $Game, $box_cover, $_user; ?>
 
 	<link href="/css/social-btn.css" rel="stylesheet">
-	<link href="/css/fa-brands.5.0.10.css" rel="stylesheet">
 	<link href="/css/jquery.fancybox.min.3.3.5.css" rel="stylesheet">
-
-	<script defer src="/js/brands.5.0.10.js" crossorigin="anonymous"></script>
 
 	<script src="/js/jquery.fancybox.3.3.5.js"></script>
 	<script src="/js/fancybox.config.js"></script>

--- a/website/user_contrib.php
+++ b/website/user_contrib.php
@@ -53,12 +53,10 @@ $Header->setTitle("TGDB - Browse - Game - $Game->game_title");
 $Header->appendRawHeader(function() { global $Game, $box_cover, $_user; ?>
 
 	<link href="/css/social-btn.css" rel="stylesheet">
-	<link href="/css/fontawesome.5.0.10.css" rel="stylesheet">
 	<link href="/css/fa-brands.5.0.10.css" rel="stylesheet">
 	<link href="/css/jquery.fancybox.min.3.3.5.css" rel="stylesheet">
 
 	<script defer src="/js/brands.5.0.10.js" crossorigin="anonymous"></script>
-	<script defer src="/js/fontawesome.5.0.10.js" crossorigin="anonymous"></script>
 
 	<script src="/js/jquery.fancybox.3.3.5.js"></script>
 	<script src="/js/fancybox.config.js"></script>


### PR DESCRIPTION
This is something I've noticed if I resize the window to anything between small (mobile) and huge (desktop) sizes. I did the following:

* Changed some padding sizes in the header
* Removed the "Home" link in the menu (as the logo functions as a home link)
* Moved the "Stats" link to under "Browse" (also added it to the footer)
* Changed the styling of the search form
* Change the column sizes in the footer

I also had to move the FontAwesome CSS/JS includes to the header file as it was now being used in the header. The `@font-face` definition was nowhere to be found so to get the icon to work I had to add that to the CSS file. I also noticed that there were some social links in the footer which were using the FontAwesome Brands icons but which didn't work so I moved the respective CSS/JS for those too.

Here are some before and after shots:

**Large**
![large](https://github.com/user-attachments/assets/9a6ab443-f41f-413b-81c2-301e257d7152)

**Medium**
![medium](https://github.com/user-attachments/assets/62d8f5ef-dd6d-43bb-81f0-764d6171433f)

**Small**
![small](https://github.com/user-attachments/assets/7970c488-8443-4e44-90ed-4aea56b81d71)
